### PR TITLE
Fixed config option reset button  

### DIFF
--- a/addons/script-name-on-top/plugin.cfg
+++ b/addons/script-name-on-top/plugin.cfg
@@ -3,5 +3,5 @@
 name="ScriptNameOnTop"
 description="Script name listed at the top of the script editor. Plus two smaller features."
 author="rainlizard"
-version="1.1"
+version="1.1.1"
 script="plugin.gd"

--- a/addons/script-name-on-top/plugin.gd
+++ b/addons/script-name-on-top/plugin.gd
@@ -264,10 +264,11 @@ func _set_plugin_settings() -> void:
 
 
 func _set_plugin_setting(config_info: Dictionary, value: Variant) -> void:
-	if ProjectSettings.has_setting(config_info["name"]): return
+	if not ProjectSettings.has_setting(config_info["name"]):
+		ProjectSettings.set_setting(config_info["name"], value)
 
-	ProjectSettings.set_setting(config_info["name"], value)
 	ProjectSettings.add_property_info(config_info)
+	ProjectSettings.set_initial_value(config_info["name"], value)
 
 
 func _get_plugin_settings() -> void:

--- a/addons/script-name-on-top/plugin.gd.uid
+++ b/addons/script-name-on-top/plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://cw8rtctds5x6p

--- a/demo/node_2d.gd.uid
+++ b/demo/node_2d.gd.uid
@@ -1,0 +1,1 @@
+uid://cp6wionnpkee7

--- a/demo/node_2d.tscn
+++ b/demo/node_2d.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://fcp6wukbi4xi"]
 
-[ext_resource type="Script" path="res://demo/node_2d.gd" id="1_rsdx6"]
+[ext_resource type="Script" uid="uid://cp6wionnpkee7" path="res://demo/node_2d.gd" id="1_rsdx6"]
 
 [node name="Node2D" type="Node2D"]
 script = ExtResource("1_rsdx6")

--- a/project.godot
+++ b/project.godot
@@ -8,16 +8,10 @@
 
 config_version=5
 
-[addons]
-
-script_name_on_top/hide_scripts_panel=false
-script_name_on_top/hide_bottom_bar=false
-script_name_on_top/show_bottom_bar_on_warning=true
-
 [application]
 
 config/name="ScriptNameOnTop"
-config/features=PackedStringArray("4.3", "Forward Plus")
+config/features=PackedStringArray("4.4", "Forward Plus")
 config/icon="res://icon.svg"
 
 [editor_plugins]


### PR DESCRIPTION
Solves https://github.com/rainlizard/ScriptNameOnTop/issues/12

Changes:
* Updated to Godot `v4.4`
* Clicking the reset button for any of the custom config options now works as expected
* Bump plugin version to `v1.1.1`