### PR TITLE
Avoid crash in 4.5

### DIFF
--- a/addons/script-name-on-top/plugin.gd
+++ b/addons/script-name-on-top/plugin.gd
@@ -225,7 +225,7 @@ func _is_main_screen_visible(screen) -> bool:
 
 
 func _get_bottom_bar() -> Control:
-	var bottom_bar: Control = _current_editor
+	var bottom_bar: Node = _current_editor
 	if not is_instance_valid(bottom_bar): return null
 
 	bottom_bar = bottom_bar.get_child(0)


### PR DESCRIPTION
4.5 apparently considers some editor a PopupPanel instead of a Control, causing the plugin to crash on project load.

I switched to a common ancestor of `PopupPanel` and `Control`.  Not sure if other `: Control` refs need to become `: Node` elsewhere, but this got rid of the errors for me.